### PR TITLE
Fix wrong `dialect_name` check

### DIFF
--- a/sqlalchemy_utils/functions/database.py
+++ b/sqlalchemy_utils/functions/database.py
@@ -429,17 +429,21 @@ def _set_url_database(url: sa.engine.url.URL, database):
 
     """
     if hasattr(url, 'set'):  # SQLAlchemy >1.4
-        return sa.engine.URL.create(
+        ret = sa.engine.URL.create(
             drivername=url.drivername,
             username=url.username,
             password=url.password,
             host=url.host,
+            port=url.port,
             database=database,
             query=url.query
         )
-    # SQLAlchemy <=1.3; mutate in place
-    url.database = database
-    return url
+    else:
+        # SQLAlchemy <=1.3; mutate in place
+        url.database = database
+        ret = url
+    assert ret.database == database, ret
+    return ret
 
 
 def _get_scalar_result(engine, sql):

--- a/sqlalchemy_utils/functions/database.py
+++ b/sqlalchemy_utils/functions/database.py
@@ -423,10 +423,10 @@ def is_auto_assigned_date_column(column):
 
 def _set_url_database(url: sa.engine.url.URL, database):
     """Set the database of an engine URL.
-    
+
     :param url: A SQLAlchemy engine URL.
     :param database: New database to set.
-    
+
     """
     if hasattr(url, 'set'):  # SQLAlchemy >1.4
         return url.set(database=database)

--- a/sqlalchemy_utils/functions/database.py
+++ b/sqlalchemy_utils/functions/database.py
@@ -429,7 +429,14 @@ def _set_url_database(url: sa.engine.url.URL, database):
 
     """
     if hasattr(url, 'set'):  # SQLAlchemy >1.4
-        return url.set(database=database)
+        return sa.engine.URL.create(
+            drivername=url.drivername,
+            username=url.username,
+            password=url.password,
+            host=url.host,
+            database=database,
+            query=url.query
+        )
     # SQLAlchemy <=1.3; mutate in place
     url.database = database
     return url

--- a/sqlalchemy_utils/functions/database.py
+++ b/sqlalchemy_utils/functions/database.py
@@ -428,7 +428,7 @@ def _set_url_database(url: sa.engine.url.URL, database):
     :param database: New database to set.
 
     """
-    if hasattr(url, 'set'):  # SQLAlchemy >1.4
+    if hasattr(sa.engine, 'URL'):
         ret = sa.engine.URL.create(
             drivername=url.drivername,
             username=url.username,
@@ -438,8 +438,7 @@ def _set_url_database(url: sa.engine.url.URL, database):
             database=database,
             query=url.query
         )
-    else:
-        # SQLAlchemy <=1.3; mutate in place
+    else:  # SQLAlchemy <1.4
         url.database = database
         ret = url
     assert ret.database == database, ret

--- a/sqlalchemy_utils/functions/database.py
+++ b/sqlalchemy_utils/functions/database.py
@@ -549,7 +549,7 @@ def create_database(url, encoding='utf8', template=None):
     dialect_name = url.get_dialect().name
     dialect_driver = url.get_dialect().driver
 
-    if dialect_name == 'postgres' or dialect_name == 'postgresql':
+    if dialect_name == 'postgresql':
         url = _set_url_database(url, database="postgres")
     elif dialect_name == 'mssql':
         url = _set_url_database(url, database="master")
@@ -617,7 +617,7 @@ def drop_database(url):
     dialect_name = url.get_dialect().name
     dialect_driver = url.get_dialect().driver
 
-    if dialect_name == 'postgres' or dialect_name == 'postgresql':
+    if dialect_name == 'postgresql':
         url = _set_url_database(url, database="postgres")
     elif dialect_name == 'mssql':
         url = _set_url_database(url, database="master")


### PR DESCRIPTION
Dug through the code and the SQLAlchemy 1.4/2.0 migrations guide and found a solution to the "incorrect database name" errors.

See:

*  [My comment](https://github.com/kvesteri/sqlalchemy-utils/pull/506#discussion_r602136763) for reference.
* [The URL object is now immutable](https://docs.sqlalchemy.org/en/14/changelog/migration_14.html#the-url-object-is-now-immutable) - SQLAlchemy migrations guide; contains an example function for implementing a forwards and backwards approach to this issue. 


